### PR TITLE
feat: 增加方法`ChoiceEnum.to_js_enum`返回数组数据

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ __pycache__/
 .DS_Store
 *.swp
 .env/
+.env*/
 .idea/
 
 build/

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ coverage: ## check code coverage quickly with the default Python
 	$(BROWSER) .coverage/htmlcov/index.html
 
 release: clean-build ## package and upload a release
-	python setup.py sdist upload -r pypi
+	${PYTHON} setup.py sdist upload -r pypi
 
 dist: clean-build ## builds source
 	${PYTHON} setup.py sdist

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A python enum module for django choices fields.
 
 ## 使用
 
-```
+```python
 # 导入
 from py_enum import ChoiceEnum, unique
 
@@ -41,6 +41,7 @@ class Status(ChoiceEnum):
 - get_label方法
 - get_extra方法
 - `直接遍历枚举类`，这是能够作为Choices Enum的关键
+
 ```
 print(Color.RED)  # 1
 type(Color.RED)  # <enum 'Color'>
@@ -57,7 +58,18 @@ for value, label in Color:
 # 1, '红色'
 # 2, '绿色'
 # 3, '蓝色'
+
+Color.to_js_enum()
+# 输出dict数据，可以通过接口序列化后给前端使用，结合js-enumerate前端枚举库
+"""
+[
+    {"key": "RED", "value": 1, "label": "红色"},
+    {"key": "GREEN", "value": 2, "label": "绿色"},
+    {"key": "BLUE", "value": 3, "label": "蓝色", "extra": {"value": "blue"}}
+]
+"""
 ```
+
 ## 枚举对象实例化
 ```
 member = Color(Color.RED)  # 或者 Color(1)
@@ -68,6 +80,16 @@ member.option == (1, '红色')  # true
 member.extra == None  # true，因为没有定义
 # 以上几个属性无法修改，直接赋值会抛出AttributeError异常
 member.value in Color  # true
+```
+
+## 在Python argparse中使用
+```
+import argparse
+
+parser = argparse.ArgumentParser(description='test ChoiceEnum use in argparse.')
+parser.add_argument('--color', type=int, choices=Color, required=True)
+args = parser.parse_args(['--color', str(Color.RED)])
+# args.color == Color.RED
 ```
 
 ## 在Django中使用
@@ -82,6 +104,7 @@ assert instance.color == colors.RED
 instance.color = colors.BLUE
 instance.save()
 ```
+
 ## 在DRF中使用
 ```
 from rest_framework import serializers
@@ -112,10 +135,8 @@ assert s.is_valid() is False  # 值不在枚举定义范围内，校验不通过
         AUTUMN = 3
         WINTER = 4
 
-## 对比
-- 和`Python3`原生enum.py对比
-  - 仅保留了`Enum`类和`unique`方法
-- 在`Python2`中使用的区别有
+# 对比
+- `Enum`可以在`Python2`中使用，但需要注意的是：
   - members无序，属性定义时申明的顺序和直接遍历枚举对象时并不一定一致；需通过`_order_`来定义member的顺序
   - python2没有定义__bool__，所以不能直接用class类或者member来做逻辑判断
   - 执行 Season.SPRING > Season.SUMMER 不会报错，但结果也不符合预期
@@ -123,3 +144,8 @@ assert s.is_valid() is False  # 值不在枚举定义范围内，校验不通过
     - 但是ChoiceEnum是直接取值，可以用来做比较运算
   - 枚举类定义时，无法识别多个相同的Key
   - 在多继承方面会受限
+- `Enum`和Python3原生enum.py对比，保留了`Enum`类和`unique`方法
+- `ChoiceEnum`和Django的 models.Choices 的优势在于低版本Django也能使用，且普通Python项目脚本也能使用
+- 新增了额外的特性
+  - 额外多出了`ChoiceEnum.extra`的用法，对不同枚举成员做映射配置相关场景可以使用
+  - 增加方法`ChoiceEnum.to_js_enum`返回数组数据，可以用于前端枚举库[js-enumerate](https://github.com/SkylerHu/js-enum)初始化使用

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # py-enum
-A python enum module for django choices fields.
+A python enum module for python2.7 and django choices fields.
 
 ## 前言
 通过改造python3中的enum.py而来，主要变更有：

--- a/docs/CHANGELOG-1.x.md
+++ b/docs/CHANGELOG-1.x.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 1.1.0 (2024-04-24)
+- feat: 增加方法`ChoiceEnum.to_js_enum`返回数组数据，可以用于前端枚举库js-enumerate使用
+- test: 补充了`ChoiceEnum`在`argparse`choice中使用的测试用例
+
 ## 1.0.1 (2023-09-28)
 - fix: 调整初始化方法`_EnumDict.py2_init`，修复Python2版本在`Enum`中使用`_ignore_`的问题
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -47,9 +47,9 @@
 - 删除本地构建缓存目录：`py_enum.egg-info`和`dist`
 - 执行打包 `python setup.py sdist`
 - 检查生成的文件是否符合pypi的要求 `twine check dist/py-enum-*.tar.gz`
-- 上传 `twine upload dist/py-enum-xxx.tar.gz`
-- 或者直接打包上传 `python setup.py sdist upload -r pypi`
+- 上传 `twine upload -r pypi dist/py-enum-xxx.tar.gz`
   - 需要本地`~/.pypirc`配置用户名密码
+- ~~或者直接打包上传 `python setup.py sdist upload -r pypi` (已废弃)~~
 
 # TODO
 - 接入`tox-travis`实现自动化发版

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -7,10 +7,11 @@
   - virtualenv --python=python2 .env
   - pyvenv3 .env
   - python3 -m venv .env
-- `pip install -U -r requirements_test.txt`
+- `pip install -U -r requirements_dev.txt`
 - 系统安装`brew install pre-commit` 或者 `pip install pre-commit`
   - brew安装`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"`
   - 在项目更目录下执行`pre-commit install --hook-type pre-commit --hook-type commit-msg`
+- 可通过`pip install -e ./`编辑模式安装用于边开发边测试使用
 
 # 项目部分结构说明
 - `pytest.ini` 测试脚本的配置

--- a/py_enum/__init__.py
+++ b/py_enum/__init__.py
@@ -3,6 +3,6 @@
 from .enum import Enum, unique  # noqa: F401,E402
 from .choice import ChoiceEnum  # noqa: F401,E402
 
-__version__ = '1.0.1'
+__version__ = '1.1.0'
 
 VERSION = __version__

--- a/py_enum/choice.py
+++ b/py_enum/choice.py
@@ -89,3 +89,19 @@ class ChoiceEnum(six.with_metaclass(EnumChoiceMeta, _ChoiceType, Enum)):
     @classmethod
     def get_extra(cls, key):
         return cls._value2member_map_[key]._extra
+
+    @classmethod
+    def to_js_enum(cls):
+        """js-enumerate 前端枚举lib需要的数据结构"""
+        arr = []
+        for key in cls._member_names_:
+            member = cls[key]
+            item = {
+                'key': key,
+                'value': member._value_,
+                'label': member._label_,
+            }
+            if member._extra is not None:
+                item['extra'] = member._extra
+            arr.append(item)
+        return arr

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -8,6 +8,8 @@ DATABASES = {
     "default": dict(ENGINE='django.db.backends.sqlite3', NAME=':memory:')
 }
 
+USE_TZ = "Asia/Shanghai"
+
 INSTALLED_APPS = (
     'django.contrib.contenttypes',
     'django.contrib.sessions',


### PR DESCRIPTION
- feat: 增加方法`ChoiceEnum.to_js_enum`返回数组数据，可以用于前端枚举库[js-enumerate](https://github.com/SkylerHu/js-enum)使用
- test: 补充了`ChoiceEnum`在`argparse`choice中使用的测试用例