### PR TITLE
feat: 扩展ChoiceEnum的使用场景

### DIFF
--- a/docs/CHANGELOG-1.x.md
+++ b/docs/CHANGELOG-1.x.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 1.1.1 (2024-05-03)
+- feat: `ChoiceEnum`增加`choices`/`values`/`labels`三个属性的访问
+- fix: `ChoiceEnum`的`__contains__`方法可用于member实例化对象的判断
+
 ## 1.1.0 (2024-04-24)
 - feat: 增加方法`ChoiceEnum.to_js_enum`返回数组数据，可以用于前端枚举库js-enumerate使用
 - test: 补充了`ChoiceEnum`在`argparse`choice中使用的测试用例

--- a/py_enum/__init__.py
+++ b/py_enum/__init__.py
@@ -3,6 +3,6 @@
 from .enum import Enum, unique  # noqa: F401,E402
 from .choice import ChoiceEnum  # noqa: F401,E402
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'
 
 VERSION = __version__

--- a/py_enum/choice.py
+++ b/py_enum/choice.py
@@ -45,7 +45,10 @@ class _ChoiceType(object):
 class EnumChoiceMeta(EnumMeta):
 
     def __contains__(cls, value):
-        return value in cls._value2member_map_
+        if not isinstance(value, Enum):
+            # Allow non-enums to match against member values.
+            return value in cls._value2member_map_
+        return super(EnumChoiceMeta, cls).__contains__(value)
 
     def __getattribute__(cls, name):
         attr = super(EnumChoiceMeta, cls).__getattribute__(name)
@@ -60,6 +63,18 @@ class EnumChoiceMeta(EnumMeta):
 
     def __iter__(cls):
         return (cls._member_map_[name].option for name in cls._member_names_)
+
+    @property
+    def choices(cls):
+        return list(cls)
+
+    @property
+    def values(cls):
+        return [value for value, _ in cls]
+
+    @property
+    def labels(cls):
+        return [label for _, label in cls]
 
 
 class ChoiceEnum(six.with_metaclass(EnumChoiceMeta, _ChoiceType, Enum)):

--- a/tests/app/enums.py
+++ b/tests/app/enums.py
@@ -9,6 +9,14 @@ class Color(ChoiceEnum):
     BLUE = (3, '蓝色')
 
 
+class OrderColor(ChoiceEnum):
+    """主要用于python2中测试用例"""
+    _order_ = 'RED GREEN BLUE'
+    RED = (1, '红色')
+    GREEN = (2, '绿色')
+    BLUE = (3, '蓝色', {'value': 'blue'})
+
+
 class Status(ChoiceEnum):
     PROCESSING = ('processing', '处理中')
     APPROVED = ('approved', '已审批')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,12 @@ def colors():
 
 
 @pytest.fixture
+def order_colors():
+    from tests.app.enums import OrderColor
+    return OrderColor
+
+
+@pytest.fixture
 def status():
     from tests.app.enums import Status
     return Status

--- a/tests/test_choice.py
+++ b/tests/test_choice.py
@@ -96,8 +96,9 @@ def test_pickle_enum(status):
 
 def test_enum_member(colors):
     assert colors['RED'].value == 1
-    assert colors(1).value == 1
-    assert colors(1) is colors['RED']
+    member = colors(1)
+    assert member.value == 1
+    assert member is colors['RED']
 
 
 def test_no_such_enum_member(colors):
@@ -107,17 +108,10 @@ def test_no_such_enum_member(colors):
         colors['GREY']
 
 
-def test_order_members(colors):
+def test_order_members(colors, order_colors):
     _colors = colors
     if six.PY2:
-        # python2需要定义排序 _order_
-        class Color(ChoiceEnum):
-            _order_ = 'RED GREEN BLUE'
-            RED = (1, '红色')
-            GREEN = (2, '绿色')
-            BLUE = (3, '蓝色')
-
-        _colors = Color
+        _colors = order_colors
     else:
         with pytest.raises(TypeError):
             # python3定义了排序，属性顺序必须一致
@@ -182,15 +176,9 @@ def test_enum_extra():
     assert Color.get_extra(Color.YELLOW) == ('first', 'second')
 
 
-def test_to_js_enum():
-    class Color(ChoiceEnum):
-        _order_ = 'RED GREEN BLUE'
-        RED = (1, '红色')
-        GREEN = (2, '绿色')
-        BLUE = (3, '蓝色', {'value': 'blue'})
-
-    items = Color.to_js_enum()
-    assert len(items) == len(Color)
+def test_to_js_enum(order_colors):
+    items = order_colors.to_js_enum()
+    assert len(items) == len(order_colors)
     expect_output = [
         {"key": "RED", "value": 1, "label": "红色"},
         {"key": "GREEN", "value": 2, "label": "绿色"},
@@ -219,7 +207,10 @@ def test_use_in_argparse(colors):
     assert args.color == test_c
 
 
-def test_cls_property(colors):
-    assert colors.values == [1, 2, 3]
-    assert colors.labels == ['红色', '绿色', '蓝色']
-    assert colors.choices == [(1, '红色'), (2, '绿色'), (3, '蓝色')]
+def test_cls_property(colors, order_colors):
+    _colors = colors
+    if six.PY2:
+        _colors = order_colors
+    assert _colors.values == [1, 2, 3]
+    assert _colors.labels == ['红色', '绿色', '蓝色']
+    assert _colors.choices == [(1, '红色'), (2, '绿色'), (3, '蓝色')]

--- a/tests/test_choice.py
+++ b/tests/test_choice.py
@@ -59,6 +59,7 @@ def test_contains(colors, status):
     assert colors.RED in colors
     assert 0 not in colors
     assert status.CLOSED in status
+    assert colors(colors.RED) in colors
 
 
 def test_enum_with_value_name_label():
@@ -216,3 +217,9 @@ def test_use_in_argparse(colors):
     args = parser.parse_args(['--color', str(test_c)])
     assert args.color is colors.RED
     assert args.color == test_c
+
+
+def test_cls_property(colors):
+    assert colors.values == [1, 2, 3]
+    assert colors.labels == ['红色', '绿色', '蓝色']
+    assert colors.choices == [(1, '红色'), (2, '绿色'), (3, '蓝色')]


### PR DESCRIPTION
- feat: `ChoiceEnum`增加`choices`/`values`/`labels`三个属性的访问
- fix: `ChoiceEnum`的`__contains__`方法可用于member实例化对象的判断
- test: add OrderColor for test in py2